### PR TITLE
Issue: #2: Use '#type' => 'help' for help form elements

### DIFF
--- a/github_labels.admin.inc
+++ b/github_labels.admin.inc
@@ -11,10 +11,9 @@
 function github_labels_settings_form($form, &$form_state) {
   $form['#config'] = 'github_labels.settings';
 
-  $form[] = array(
+  $form['help'] = array(
+    '#type' => 'help';
     '#markup' => t('Enter one or more GitHub repositories to create tokens and CSS for GitHub labels. The labels will be formatted to match their appearance in GitHub. If you specify multiple repositories that define the same label name, the formatting used will be the repository that appears first in the list below.'),
-    '#prefix' => '<p>',
-    '#suffix' => '</p>',
   );
 
   $form['repositories'] = array(
@@ -58,11 +57,9 @@ function github_labels_settings_form_submit($form, &$form_state) {
 function github_labels_report_page() {
   $build = array();
   if (!module_exists('token')) {
-    $link = l(t('install and enable the Token Filter module'), 'https://backdropcms.org/project/token_filter');
-    $build[] = array(
-      '#markup' => t('You will need to !link to use the tokens within text fields.', array('!link' => $link)),
-      '#prefix' => '<p>',
-      '#suffix' => '</p>',
+    $build['help'] = array(
+      '#type' => 'help';
+      '#markup' => t('You will need to install and enable the <a href="@url">Token Filter module</a> to use the tokens within text fields.', array('@url' => 'https://backdropcms.org/project/token_filter')),
     );
   }
   $labels_info = github_labels_info();


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/github_labels/issues/2

Also puts the link within `t()`. See the good vs bad examples section in [Dynamic or static links and HTML in translatable strings](https://www.drupal.org/node/322774).